### PR TITLE
API 0.1: Generate serial numbers for sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ licensed under the same license.
 
 ## Changelog
 
+### naucse_render 1.2
+
+* API version 0.1
+* Serial "numbers" are now generated for sessions.
+  * Serials are strings (or None). Usually they are numeric (like `'1'`),
+    and in the source YAML they may be specified as int.
+    But, for example, an appendix could use Roman numerals: `i`, `ii`, `iii`.
+  * When a serial is not given in the source YAML explicitly, it is
+    auto-generated as the previous serial plus 1 (or from `1` at the start).
+    Serials specified as str (or None) prevent this auto-generation.
+  * For courses with only one session, the serial is not auto-generated.
+
+
 ### naucse_render 1.1
 
 * Make it possible to use data from a YAML file in lesson content

--- a/naucse_render/course.py
+++ b/naucse_render/course.py
@@ -107,7 +107,9 @@ def get_course(course_slug: str, *, path='.', version=None):
 
         if 'serial' in session:
             last_serial = session['serial']
-            if last_serial is not None:
+            if last_serial is None:
+                del session['serial']
+            else:
                 session['serial'] = str(last_serial)
                 if not isinstance(last_serial, (int, str)):
                     tp = type(last_serial).__name__

--- a/naucse_render/course.py
+++ b/naucse_render/course.py
@@ -109,6 +109,11 @@ def get_course(course_slug: str, *, path='.', version=None):
             last_serial = session['serial']
             if last_serial is not None:
                 session['serial'] = str(last_serial)
+                if not isinstance(last_serial, (int, str)):
+                    tp = type(last_serial).__name__
+                    raise TypeError(
+                        f'The serial should be str, int or None; got {tp}'
+                    )
         elif isinstance(last_serial, int) and len(info['sessions']) > 1:
             last_serial += 1
             session['serial'] = str(last_serial)

--- a/naucse_render/course.py
+++ b/naucse_render/course.py
@@ -107,7 +107,8 @@ def get_course(course_slug: str, *, path='.', version=None):
 
         if 'serial' in session:
             last_serial = session['serial']
-            session['serial'] = str(last_serial)
+            if last_serial is not None:
+                session['serial'] = str(last_serial)
         elif isinstance(last_serial, int) and len(info['sessions']) > 1:
             last_serial += 1
             session['serial'] = str(last_serial)

--- a/naucse_render/encode.py
+++ b/naucse_render/encode.py
@@ -1,6 +1,8 @@
 from pathlib import PurePath, PurePosixPath
 import datetime
 
+API_VERSION = (0, 1)  # Version 0.1
+
 
 def encode_for_json(value):
     """Convert "value" to use only basic, JSON-compatible data types

--- a/naucse_render/lesson.py
+++ b/naucse_render/lesson.py
@@ -11,7 +11,7 @@ import textwrap
 
 from .load import read_yaml
 from .page import render_page
-from .encode import encode_for_json
+from .encode import encode_for_json, API_VERSION
 
 
 def get_lessons(lesson_slugs, vars=None, path='.'):
@@ -31,10 +31,10 @@ def get_lessons(lesson_slugs, vars=None, path='.'):
             pass
         else:
             data[slug] = lesson_data
-    return {
-        'api_version': [0, 0],
-        'data': encode_for_json(data),
-    }
+    return encode_for_json({
+        'api_version': API_VERSION,
+        'data': data,
+    })
 
 
 def get_lesson(lesson_slug, vars, base_path):

--- a/naucse_render/load.py
+++ b/naucse_render/load.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import functools
 import sys
+import copy
 
 import yaml
 
@@ -30,7 +31,7 @@ def read_yaml(base_path, *path_parts, source_key=None):
     if base_path not in yaml_path.parents:
         raise ValueError(f'Invalid path')
 
-    result = dict(_read_yaml(yaml_path, yaml_path.stat()))
+    result = copy.deepcopy(_read_yaml(yaml_path, yaml_path.stat()))
     if source_key:
         result[source_key] = '/'.join(path_parts)
     return result

--- a/test_naucse_render/fixtures/expected-dumps/2000/run-with-times.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/2000/run-with-times.yaml
@@ -1,6 +1,6 @@
 api_version:
 - 0
-- 0
+- 1
 course:
     default_time:
         end: '21:00'

--- a/test_naucse_render/fixtures/expected-dumps/2000/run-without-times.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/2000/run-without-times.yaml
@@ -1,6 +1,6 @@
 api_version:
 - 0
-- 0
+- 1
 course:
     sessions:
     -   date: '2000-01-01'

--- a/test_naucse_render/fixtures/expected-dumps/beginners/install-editor.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/beginners/install-editor.yaml
@@ -1,6 +1,6 @@
 api_version:
 - 0
-- 0
+- 1
 data:
     beginners/install-editor:
         pages:

--- a/test_naucse_render/fixtures/expected-dumps/courses/normal-course.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/courses/normal-course.yaml
@@ -1,6 +1,6 @@
 api_version:
 - 0
-- 0
+- 1
 course:
     sessions:
     -   slug: normal-lesson

--- a/test_naucse_render/fixtures/expected-dumps/courses/serial-test.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/courses/serial-test.yaml
@@ -11,11 +11,11 @@ course:
         slug: autonumber-2
         source_file: courses/serial-test/info.yml
         title: Autonumber 2
-    -   serial: None
+    -   serial: null
         slug: no-serial-1
         source_file: courses/serial-test/info.yml
         title: No Serial 1
-    -   serial: None
+    -   serial: null
         slug: no-serial-2
         source_file: courses/serial-test/info.yml
         title: No Serial 2
@@ -23,7 +23,7 @@ course:
         slug: string-serial-2
         source_file: courses/serial-test/info.yml
         title: String Serial 2
-    -   serial: None
+    -   serial: null
         slug: no-serial-3
         source_file: courses/serial-test/info.yml
         title: No Serial 3
@@ -31,7 +31,7 @@ course:
         slug: string-serial-iv
         source_file: courses/serial-test/info.yml
         title: String Serial-iv
-    -   serial: None
+    -   serial: null
         slug: no-serial-4
         source_file: courses/serial-test/info.yml
         title: No Serial 4

--- a/test_naucse_render/fixtures/expected-dumps/courses/serial-test.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/courses/serial-test.yaml
@@ -11,28 +11,24 @@ course:
         slug: autonumber-2
         source_file: courses/serial-test/info.yml
         title: Autonumber 2
-    -   serial: null
-        slug: no-serial-1
+    -   slug: no-serial-1
         source_file: courses/serial-test/info.yml
         title: No Serial 1
-    -   serial: null
-        slug: no-serial-2
+    -   slug: no-serial-2
         source_file: courses/serial-test/info.yml
         title: No Serial 2
     -   serial: '2'
         slug: string-serial-2
         source_file: courses/serial-test/info.yml
         title: String Serial 2
-    -   serial: null
-        slug: no-serial-3
+    -   slug: no-serial-3
         source_file: courses/serial-test/info.yml
         title: No Serial 3
     -   serial: iv
         slug: string-serial-iv
         source_file: courses/serial-test/info.yml
         title: String Serial-iv
-    -   serial: null
-        slug: no-serial-4
+    -   slug: no-serial-4
         source_file: courses/serial-test/info.yml
         title: No Serial 4
     -   serial: '5'

--- a/test_naucse_render/fixtures/expected-dumps/courses/serial-test.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/courses/serial-test.yaml
@@ -1,0 +1,51 @@
+api_version:
+- 0
+- 1
+course:
+    sessions:
+    -   serial: '1'
+        slug: autonumber-1
+        source_file: courses/serial-test/info.yml
+        title: Autonumber 1
+    -   serial: '2'
+        slug: autonumber-2
+        source_file: courses/serial-test/info.yml
+        title: Autonumber 2
+    -   serial: None
+        slug: no-serial-1
+        source_file: courses/serial-test/info.yml
+        title: No Serial 1
+    -   serial: None
+        slug: no-serial-2
+        source_file: courses/serial-test/info.yml
+        title: No Serial 2
+    -   serial: '2'
+        slug: string-serial-2
+        source_file: courses/serial-test/info.yml
+        title: String Serial 2
+    -   serial: None
+        slug: no-serial-3
+        source_file: courses/serial-test/info.yml
+        title: No Serial 3
+    -   serial: iv
+        slug: string-serial-iv
+        source_file: courses/serial-test/info.yml
+        title: String Serial-iv
+    -   serial: None
+        slug: no-serial-4
+        source_file: courses/serial-test/info.yml
+        title: No Serial 4
+    -   serial: '5'
+        slug: int-serial-5
+        source_file: courses/serial-test/info.yml
+        title: Int Serial 5
+    -   serial: '6'
+        slug: autonumber-6
+        source_file: courses/serial-test/info.yml
+        title: Autonumber 6
+    -   serial: '6'
+        slug: int-serial-6
+        source_file: courses/serial-test/info.yml
+        title: Int Serial 6
+    source_file: courses/serial-test/info.yml
+    title: A course to test handling of "serial" numbers/strings

--- a/test_naucse_render/fixtures/expected-dumps/homework/tasks.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/homework/tasks.yaml
@@ -1,6 +1,6 @@
 api_version:
 - 0
-- 0
+- 1
 data:
     homework/tasks:
         pages:

--- a/test_naucse_render/fixtures/expected-dumps/lessons.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/lessons.yaml
@@ -1,6 +1,6 @@
 api_version:
 - 0
-- 0
+- 1
 course:
     description: "Seznam udr\u017Eovan\xFDch lekc\xED bez ladu a skladu."
     long_description: "<p>Seznam udr\u017Eovan\xFDch lekc\xED bez ladu a skladu.</p>\n\
@@ -11,6 +11,7 @@ course:
         -   lesson_slug: beginners/install-editor
             title: Instalace editoru
             type: lesson
+        serial: '1'
         slug: beginners
         source_file: lessons
         title: '`beginners`'
@@ -18,6 +19,7 @@ course:
         -   lesson_slug: homework/tasks
             title: Tasks
             type: lesson
+        serial: '2'
         slug: homework
         source_file: lessons
         title: '`homework`'
@@ -25,6 +27,7 @@ course:
         -   lesson_slug: testcases/test_static_tree
             title: Tree of static files
             type: lesson
+        serial: '3'
         slug: testcases
         source_file: lessons
         title: '`testcases`'

--- a/test_naucse_render/fixtures/expected-dumps/testcases/test_static_tree.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/testcases/test_static_tree.yaml
@@ -1,6 +1,6 @@
 api_version:
 - 0
-- 0
+- 1
 data:
     testcases/test_static_tree:
         pages:

--- a/test_naucse_render/fixtures/test_content/courses/bad-serial/info.yml
+++ b/test_naucse_render/fixtures/test_content/courses/bad-serial/info.yml
@@ -1,0 +1,6 @@
+title: A course to test handling of wrong type of "serial"
+
+sessions:
+- title: Bad serial type
+  slug: bad-serial
+  serial: ['a', 'list']

--- a/test_naucse_render/fixtures/test_content/courses/serial-test/info.yml
+++ b/test_naucse_render/fixtures/test_content/courses/serial-test/info.yml
@@ -1,0 +1,43 @@
+title: A course to test handling of "serial" numbers/strings
+
+sessions:
+- title: Autonumber 1
+  slug: autonumber-1
+
+- title: Autonumber 2
+  slug: autonumber-2
+
+- title: No Serial 1
+  slug: no-serial-1
+  serial: null
+
+- title: No Serial 2
+  slug: no-serial-2
+  serial: null
+
+- title: String Serial 2
+  slug: string-serial-2
+  serial: '2'
+
+- title: No Serial 3
+  slug: no-serial-3
+  serial: null
+
+- title: String Serial-iv
+  slug: string-serial-iv
+  serial: 'iv'
+
+- title: No Serial 4
+  slug: no-serial-4
+  serial: null
+
+- title: Int Serial 5
+  slug: int-serial-5
+  serial: 5
+
+- title: Autonumber 6
+  slug: autonumber-6
+
+- title: Int Serial 6
+  slug: int-serial-6
+  serial: 6

--- a/test_naucse_render/test_integration.py
+++ b/test_naucse_render/test_integration.py
@@ -33,3 +33,15 @@ def test_render_lesson(slug):
     path = fixture_path / 'test_content'
     lesson_info = naucse_render.get_lessons([slug], path=str(path))
     assert_yaml_dump(lesson_info, slug + '.yaml')
+
+
+@pytest.mark.parametrize(
+    ['slug', 'exception_type'],
+    [
+        ('courses/bad-serial', TypeError),
+    ],
+)
+def test_negative_course(slug, exception_type):
+    path = fixture_path / 'test_content'
+    with pytest.raises(exception_type):
+        lesson_info = naucse_render.get_course(slug, path=str(path))

--- a/test_naucse_render/test_integration.py
+++ b/test_naucse_render/test_integration.py
@@ -9,6 +9,7 @@ from test_naucse_render.conftest import assert_yaml_dump, fixture_path
     'slug',
     [
         'courses/normal-course',
+        'courses/serial-test',
         '2000/run-without-times',
         '2000/run-with-times',
         'lessons',

--- a/test_naucse_render/test_load.py
+++ b/test_naucse_render/test_load.py
@@ -60,7 +60,8 @@ def test_read_yaml_disallow_parents(tmp_path):
 
 
 def test_isolated_load(tmp_path):
-    """Assert that read_yaml cache is invalidated when the file changes"""
+    """Assert changing the data returned from read_yaml won't poison the cache
+    by changing the data in place."""
     yaml_path = tmp_path / 'test.yaml'
     yaml_path.write_text("""data:
         a: 1

--- a/test_naucse_render/test_load.py
+++ b/test_naucse_render/test_load.py
@@ -57,3 +57,18 @@ def test_read_yaml_disallow_parents(tmp_path):
     """Assert that read_yaml cache is invalidated when the file changes"""
     with pytest.raises(ValueError):
         read_yaml(tmp_path, '../../test.yaml')
+
+
+def test_isolated_load(tmp_path):
+    """Assert that read_yaml cache is invalidated when the file changes"""
+    yaml_path = tmp_path / 'test.yaml'
+    yaml_path.write_text("""data:
+        a: 1
+        b: 2
+    """)
+    data = read_yaml(tmp_path, 'test.yaml')
+    assert data == {'data': {'a': 1, 'b': 2}}
+    del data['data']['a']
+
+    data = read_yaml(tmp_path, 'test.yaml')
+    assert data == {'data': {'a': 1, 'b': 2}}


### PR DESCRIPTION
See https://github.com/pyvec/naucse.python.cz/pull/528 for more context

Serial "numbers" are now generated for sessions.
* Serials are strings (or None). Usually they are numeric (like `'1'`),
    and in the source YAML they may be specified as int.
    But, for example, an appendix could use Roman numerals: `i`, `ii`, `iii`.
* When a serial is not given in the source YAML explicitly, it is
    auto-generated as the previous serial plus 1 (or from `1` at the start).
    Serials specified as str (or None) prevent this auto-generation.
* For courses with only one session, the serial is not auto-generated.