### PR TITLE
Start API 0.2: page subtitles, timezone, disallow duplicate keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ licensed under the same license.
 
 * Lesson directories without data are ignored
   (https://github.com/pyvec/naucse_render/issues/15)
+* API version 0.2
 
 
 ### naucse_render 1.2

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ licensed under the same license.
     as `"{lesson title} – {page subtitle}"`.
 * Timezone information is passed through
 * Mappings read from YAML must have unique keys.
+* Subpages may now be linked with relative URLs: `./page`, just like
+  other lessons can be linked with `../lesson` or `../../category/lesson`.
+  ("Short" linking to subpages of other lessons, like ~~`../lesson/page`~~,
+  still doesn't work.)
 
 
 ### naucse_render 1.2

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ licensed under the same license.
   * If the `title` of a non-`index` subpage may now be missing in the input.
     In that case, the `subtitle` must be present, and the `title` is generated
     as `"{lesson title} – {page subtitle}"`.
+* Timezone information is passed through
 
 
 ### naucse_render 1.2

--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ licensed under the same license.
 * Lesson directories without data are ignored
   (https://github.com/pyvec/naucse_render/issues/15)
 * API version 0.2
+* Subpages now have subtitles
+  * Non-`index` subpages may optionally have a `subtitle`. For example,
+    a lesson named "Installation" might have a OS-specific subpage with the
+    subtitle "Linux".
+  * If the `title` of a non-`index` subpage may now be missing in the input.
+    In that case, the `subtitle` must be present, and the `title` is generated
+    as `"{lesson title} – {page subtitle}"`.
 
 
 ### naucse_render 1.2

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ licensed under the same license.
     In that case, the `subtitle` must be present, and the `title` is generated
     as `"{lesson title} – {page subtitle}"`.
 * Timezone information is passed through
+* Mappings read from YAML must have unique keys.
 
 
 ### naucse_render 1.2

--- a/naucse_render/encode.py
+++ b/naucse_render/encode.py
@@ -1,7 +1,7 @@
 from pathlib import PurePath, PurePosixPath
 import datetime
 
-API_VERSION = (0, 1)  # Version 0.1
+API_VERSION = (0, 2)  # Version 0.2
 
 
 def encode_for_json(value):

--- a/naucse_render/lesson.py
+++ b/naucse_render/lesson.py
@@ -56,10 +56,15 @@ def get_lesson(lesson_slug, vars, base_path):
     lesson_vars = lesson_info.pop('vars', {})
 
     pages_info = lesson_info.pop('subpages', {})
-    pages_info.setdefault('index', {})
-
+    pages_info.setdefault('index', {'title': lesson_info['title']})
     for slug, page_info in pages_info.items():
-        info = {**lesson_info, **page_info}
+        info = {**lesson_info, 'title': None, **page_info}
+        if 'title' not in page_info:
+            try:
+                subtitle = info['subtitle']
+            except KeyError:
+                raise ValueError(f"'subtitle' is required for page {lesson_slug}/{slug}")
+            info['title'] = f"{lesson_info['title']} – {subtitle}"
         lesson['pages'][slug] = render_page(
             lesson_slug, slug, info, vars={**vars, **lesson_vars},
             path=base_path,

--- a/naucse_render/page.py
+++ b/naucse_render/page.py
@@ -92,6 +92,10 @@ def render_page(lesson_slug, page_slug, info, path, vars=None):
     }
     if 'license_code' in info:
         page['license_code'] = info['license_code']
+    if 'subtitle' in info:
+        if page_slug == 'index':
+            raise ValueError('Index pages may not have a subtitle')
+        page['subtitle'] = info['subtitle']
 
     # Page content can be read from Markdown (md) or Jupyter Notebook (ipynb),
     # selected by 'style'.

--- a/naucse_render/page.py
+++ b/naucse_render/page.py
@@ -2,6 +2,7 @@ from pathlib import Path, PurePosixPath
 from urllib.parse import urlparse
 import types
 import sys
+import re
 
 import jinja2
 
@@ -64,6 +65,9 @@ def rewrite_relative_url(url, slug):
         group, name = slug.split('/')
         [name] = parts
         return lesson_url(f'{group}/{name}', _anchor=parsed.fragment)
+
+    if parsed.path.startswith('./') and len(parts) == 1:
+        return lesson_url(slug, page=parts[0])
 
     if parsed.path.startswith('.'):
         raise ValueError(url)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
 
 setup(
     name='naucse_render',
-    version='1.2',
+    version='1.3',
     description='Converts course material to naucse.python.cz API',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/test_naucse_render/fixtures/expected-dumps/2000/run-with-times.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/2000/run-with-times.yaml
@@ -1,6 +1,6 @@
 api_version:
 - 0
-- 1
+- 2
 course:
     default_time:
         end: '21:00'

--- a/test_naucse_render/fixtures/expected-dumps/2000/run-with-timezone.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/2000/run-with-timezone.yaml
@@ -1,0 +1,15 @@
+api_version:
+- 0
+- 2
+course:
+    default_time:
+        end: '21:00'
+        start: 19:00+01:00
+    sessions:
+    -   date: '2000-01-01'
+        slug: normal-lesson
+        source_file: runs/2000/run-with-timezone/info.yml
+        title: A normal lesson
+    source_file: runs/2000/run-with-timezone/info.yml
+    timezone: Europe/Bratislava
+    title: Test run with scheduled times

--- a/test_naucse_render/fixtures/expected-dumps/2000/run-without-times.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/2000/run-without-times.yaml
@@ -1,6 +1,6 @@
 api_version:
 - 0
-- 1
+- 2
 course:
     sessions:
     -   date: '2000-01-01'

--- a/test_naucse_render/fixtures/expected-dumps/beginners/install-editor.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/beginners/install-editor.yaml
@@ -1,6 +1,6 @@
 api_version:
 - 0
-- 1
+- 2
 data:
     beginners/install-editor:
         pages:

--- a/test_naucse_render/fixtures/expected-dumps/courses/normal-course.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/courses/normal-course.yaml
@@ -1,6 +1,6 @@
 api_version:
 - 0
-- 1
+- 2
 course:
     sessions:
     -   slug: normal-lesson

--- a/test_naucse_render/fixtures/expected-dumps/courses/serial-test.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/courses/serial-test.yaml
@@ -1,6 +1,6 @@
 api_version:
 - 0
-- 1
+- 2
 course:
     sessions:
     -   serial: '1'

--- a/test_naucse_render/fixtures/expected-dumps/homework/tasks.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/homework/tasks.yaml
@@ -1,6 +1,6 @@
 api_version:
 - 0
-- 1
+- 2
 data:
     homework/tasks:
         pages:

--- a/test_naucse_render/fixtures/expected-dumps/lessons.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/lessons.yaml
@@ -1,6 +1,6 @@
 api_version:
 - 0
-- 1
+- 2
 course:
     description: "Seznam udr\u017Eovan\xFDch lekc\xED bez ladu a skladu."
     long_description: "<p>Seznam udr\u017Eovan\xFDch lekc\xED bez ladu a skladu.</p>\n\

--- a/test_naucse_render/fixtures/expected-dumps/lessons.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/lessons.yaml
@@ -27,6 +27,9 @@ course:
         -   lesson_slug: testcases/test_static_tree
             title: Tree of static files
             type: lesson
+        -   lesson_slug: testcases/test_subpages
+            title: Subpages
+            type: lesson
         serial: '3'
         slug: testcases
         source_file: lessons

--- a/test_naucse_render/fixtures/expected-dumps/testcases/test_static_tree.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/testcases/test_static_tree.yaml
@@ -1,6 +1,6 @@
 api_version:
 - 0
-- 1
+- 2
 data:
     testcases/test_static_tree:
         pages:

--- a/test_naucse_render/fixtures/expected-dumps/testcases/test_subpages.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/testcases/test_subpages.yaml
@@ -1,0 +1,51 @@
+api_version:
+- 0
+- 2
+data:
+    testcases/test_subpages:
+        pages:
+            both-titles:
+                attribution:
+                - Petr Viktorin
+                content: <p>This has both an explicit title and subtitle.</p>
+                license: cc0
+                slug: both-titles
+                solutions: []
+                source_file: lessons/testcases/test_subpages/both-titles.md
+                subtitle: Both Titles
+                title: Subpages (Both Titles)
+                vars: {}
+            index:
+                attribution:
+                - Petr Viktorin
+                content: <p>This is the main page.</p>
+                license: cc0
+                slug: index
+                solutions: []
+                source_file: lessons/testcases/test_subpages/index.md
+                title: Subpages
+                vars: {}
+            subtitled:
+                attribution:
+                - Petr Viktorin
+                content: <p>This has an explicit subtitle.</p>
+                license: cc0
+                slug: subtitled
+                solutions: []
+                source_file: lessons/testcases/test_subpages/subtitled.md
+                subtitle: Subtitled
+                title: "Subpages \u2013 Subtitled"
+                vars: {}
+            titled:
+                attribution:
+                - Petr Viktorin
+                content: <p>This has an explicit title.</p>
+                license: cc0
+                slug: titled
+                solutions: []
+                source_file: lessons/testcases/test_subpages/titled.md
+                title: Subpages (Titled)
+                vars: {}
+        source_file: lessons/testcases/test_subpages/info.yml
+        static_files: {}
+        title: Subpages

--- a/test_naucse_render/fixtures/expected-dumps/testcases/test_subpages.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/testcases/test_subpages.yaml
@@ -18,7 +18,9 @@ data:
             index:
                 attribution:
                 - Petr Viktorin
-                content: <p>This is the main page.</p>
+                content: <p>This is the main page with links to subpages <a href="naucse:page?lesson=testcases/test_subpages&amp;page=titled">one</a>,
+                    <a href="naucse:page?lesson=testcases/test_subpages&amp;page=subtitled">two</a>
+                    and <a href="naucse:page?lesson=testcases/test_subpages&amp;page=both-titles">three</a>.</p>
                 license: cc0
                 slug: index
                 solutions: []

--- a/test_naucse_render/fixtures/test_content/lessons/testcases/test_subpages/both-titles.md
+++ b/test_naucse_render/fixtures/test_content/lessons/testcases/test_subpages/both-titles.md
@@ -1,0 +1,1 @@
+This has both an explicit title and subtitle.

--- a/test_naucse_render/fixtures/test_content/lessons/testcases/test_subpages/index.md
+++ b/test_naucse_render/fixtures/test_content/lessons/testcases/test_subpages/index.md
@@ -1,1 +1,5 @@
-This is the main page.
+This is the main page with links to subpages [one], [two] and [three].
+
+[one]: ./titled
+[two]: ./subtitled
+[three]: ./both-titles

--- a/test_naucse_render/fixtures/test_content/lessons/testcases/test_subpages/index.md
+++ b/test_naucse_render/fixtures/test_content/lessons/testcases/test_subpages/index.md
@@ -1,0 +1,1 @@
+This is the main page.

--- a/test_naucse_render/fixtures/test_content/lessons/testcases/test_subpages/info.yml
+++ b/test_naucse_render/fixtures/test_content/lessons/testcases/test_subpages/info.yml
@@ -1,0 +1,12 @@
+title: Subpages
+style: md
+attribution: Petr Viktorin
+subpages:
+    titled:
+        title: "Subpages (Titled)"
+    subtitled:
+        subtitle: "Subtitled"
+    both-titles:
+        title: "Subpages (Both Titles)"
+        subtitle: "Both Titles"
+license: cc0

--- a/test_naucse_render/fixtures/test_content/lessons/testcases/test_subpages/subtitled.md
+++ b/test_naucse_render/fixtures/test_content/lessons/testcases/test_subpages/subtitled.md
@@ -1,0 +1,1 @@
+This has an explicit subtitle.

--- a/test_naucse_render/fixtures/test_content/lessons/testcases/test_subpages/titled.md
+++ b/test_naucse_render/fixtures/test_content/lessons/testcases/test_subpages/titled.md
@@ -1,0 +1,1 @@
+This has an explicit title.

--- a/test_naucse_render/fixtures/test_content/runs/2000/run-with-timezone/info.yml
+++ b/test_naucse_render/fixtures/test_content/runs/2000/run-with-timezone/info.yml
@@ -1,0 +1,10 @@
+title: Test run with scheduled times
+timezone: Europe/Bratislava
+default_time:
+  start: '19:00+01:00'
+  end: '21:00'
+
+plan:
+- title: A normal lesson
+  slug: normal-lesson
+  date: 2000-01-01

--- a/test_naucse_render/test_integration.py
+++ b/test_naucse_render/test_integration.py
@@ -12,6 +12,7 @@ from test_naucse_render.conftest import assert_yaml_dump, fixture_path
         'courses/serial-test',
         '2000/run-without-times',
         '2000/run-with-times',
+        '2000/run-with-timezone',
         'lessons',
     ],
 )

--- a/test_naucse_render/test_integration.py
+++ b/test_naucse_render/test_integration.py
@@ -27,6 +27,7 @@ def test_render_course(slug):
         'beginners/install-editor',
         'homework/tasks',
         'testcases/test_static_tree',
+        'testcases/test_subpages',
     ],
 )
 def test_render_lesson(slug):


### PR DESCRIPTION
This provides the `naucse_render` side fixes for:
- https://github.com/pyvec/naucse/issues/20 – Breadcrumbs don't respect subpages
- https://github.com/pyvec/naucse/issues/13 – API: Time information lacks timezone info
- https://github.com/pyvec/naucse/issues/2 – Prevent duplicate slugs
- (partially) https://github.com/pyvec/naucse_render/issues/7 – Automatically convert ./linux to {{ subpage_url('linux') }}

For most of these, `naucse` will also need an update to use the new information.