### PR TITLE
Add anchor links to headers

### DIFF
--- a/naucse_render/markdown.py
+++ b/naucse_render/markdown.py
@@ -142,7 +142,7 @@ class Renderer(mistune.Renderer):
     def header(self, text, level, raw=None):
         header_id = text_to_id(text)
         return f'''<h{level:d} id="{header_id}">{text}
-<a href="#{header_id}" class="permanent-link">#</a>
+<a href="#header-{header_id}" class="header-link">#</a>
 </h{level:d}>\n'''
 
     def block_code(self, code, lang):

--- a/naucse_render/markdown.py
+++ b/naucse_render/markdown.py
@@ -1,3 +1,4 @@
+import unicodedata
 from textwrap import dedent
 import re
 
@@ -107,6 +108,27 @@ def get_lexer_by_name(lang):
     return pygments.lexers.get_lexer_by_name(lang)
 
 
+# https://stackoverflow.com/a/31607735/1107768
+def strip_accents(text: str) -> str:
+    """
+    Strip accents from input string.
+    """
+    text = unicodedata.normalize('NFD', text)
+    text = text.encode('ascii', 'ignore')
+    text = text.decode("utf-8")
+    return str(text)
+
+
+def text_to_id(text):
+    """
+    Convert input text to id.
+    """
+    text = strip_accents(text.lower())
+    text = re.sub('[ ]+', '_', text)
+    text = re.sub('[^0-9a-zA-Z_-]', '', text)
+    return text
+
+
 class Renderer(mistune.Renderer):
     code_tmpl = '<div class="highlight"><pre><code>{}</code></pre></div>'
 
@@ -116,6 +138,12 @@ class Renderer(mistune.Renderer):
 
     def admonition(self, name, content):
         return '<div class="admonition {}">{}</div>'.format(name, content)
+
+    def header(self, text, level, raw=None):
+        header_id = text_to_id(text)
+        return f'''<h{level:d} id="{header_id}">{text}
+<a href="#{header_id}" class="permanent-link">#</a>
+</h{level:d}>\n'''
 
     def block_code(self, code, lang):
         if lang is not None:

--- a/test_naucse_render/fixtures/expected-compiled/default/install-editor/atom.html
+++ b/test_naucse_render/fixtures/expected-compiled/default/install-editor/atom.html
@@ -1,11 +1,19 @@
-<h1>Instalace  Atomu</h1>
+<h1 id="instalace_atomu">Instalace  Atomu
+<a href="#instalace_atomu" class="permanent-link">#</a>
+</h1>
 <p>Editor Atom
 si stáhni z jeho <a href="https://atom.io">domovské stránky</a>
 a nainstaluj.</p>
-<h2>Nastavení</h2>
+<h2 id="nastaveni">Nastavení
+<a href="#nastaveni" class="permanent-link">#</a>
+</h2>
 <p>... jakmile v tomhle editoru vytvoříš nový soubor,
 měl/a bys ho co nejdřív uložit pod správným jménem.</p>
-<h2>Kontrola stylu zdrojového kódu</h2>
+<h2 id="kontrola_stylu_zdrojoveho_kodu">Kontrola stylu zdrojového kódu
+<a href="#kontrola_stylu_zdrojoveho_kodu" class="permanent-link">#</a>
+</h2>
 <p>...</p>
-<h2>Nácvik odsazování</h2>
+<h2 id="nacvik_odsazovani">Nácvik odsazování
+<a href="#nacvik_odsazovani" class="permanent-link">#</a>
+</h2>
 <p>...</p>

--- a/test_naucse_render/fixtures/expected-compiled/default/install-editor/atom.html
+++ b/test_naucse_render/fixtures/expected-compiled/default/install-editor/atom.html
@@ -1,19 +1,19 @@
 <h1 id="instalace_atomu">Instalace  Atomu
-<a href="#instalace_atomu" class="permanent-link">#</a>
+<a href="#header-instalace_atomu" class="header-link">#</a>
 </h1>
 <p>Editor Atom
 si stáhni z jeho <a href="https://atom.io">domovské stránky</a>
 a nainstaluj.</p>
 <h2 id="nastaveni">Nastavení
-<a href="#nastaveni" class="permanent-link">#</a>
+<a href="#header-nastaveni" class="header-link">#</a>
 </h2>
 <p>... jakmile v tomhle editoru vytvoříš nový soubor,
 měl/a bys ho co nejdřív uložit pod správným jménem.</p>
 <h2 id="kontrola_stylu_zdrojoveho_kodu">Kontrola stylu zdrojového kódu
-<a href="#kontrola_stylu_zdrojoveho_kodu" class="permanent-link">#</a>
+<a href="#header-kontrola_stylu_zdrojoveho_kodu" class="header-link">#</a>
 </h2>
 <p>...</p>
 <h2 id="nacvik_odsazovani">Nácvik odsazování
-<a href="#nacvik_odsazovani" class="permanent-link">#</a>
+<a href="#header-nacvik_odsazovani" class="header-link">#</a>
 </h2>
 <p>...</p>

--- a/test_naucse_render/fixtures/expected-compiled/default/install-editor/gedit.html
+++ b/test_naucse_render/fixtures/expected-compiled/default/install-editor/gedit.html
@@ -1,5 +1,5 @@
 <h1 id="instalace_geditu">Instalace  Geditu
-<a href="#instalace_geditu" class="permanent-link">#</a>
+<a href="#header-instalace_geditu" class="header-link">#</a>
 </h1>
 <p>Na Linuxu se Gedit instaluje jako ostatní programy:</p>
 <dl>
@@ -8,7 +8,7 @@
 </pre></div></dd></dl><p>Používáš-li jiný Linux, předpokládám že programy instalovat umíš. :)</p>
 <p>Pro Windows a macOS se Gedit dá stáhnout z <a href="https://wiki.gnome.org/Apps/Gedit">domovské stránky</a>.</p>
 <h2 id="nastaveni">Nastavení
-<a href="#nastaveni" class="permanent-link">#</a>
+<a href="#header-nastaveni" class="header-link">#</a>
 </h2>
 <p>...</p>
 <dl>
@@ -17,6 +17,6 @@ Zobrazovat čísla řádků/<span class="en">Display Line Numbers</span>.</p>
 <p><span class="figure"><a href="naucse:static?filename=gedit_linenums.png"><img src="naucse:static?filename=gedit_linenums.png" alt=""></a></span></p>
 </dd></dl><p>...</p>
 <h2 id="nacvik_odsazovani">Nácvik odsazování
-<a href="#nacvik_odsazovani" class="permanent-link">#</a>
+<a href="#header-nacvik_odsazovani" class="header-link">#</a>
 </h2>
 <p>...</p>

--- a/test_naucse_render/fixtures/expected-compiled/default/install-editor/gedit.html
+++ b/test_naucse_render/fixtures/expected-compiled/default/install-editor/gedit.html
@@ -1,16 +1,22 @@
-<h1>Instalace  Geditu</h1>
+<h1 id="instalace_geditu">Instalace  Geditu
+<a href="#instalace_geditu" class="permanent-link">#</a>
+</h1>
 <p>Na Linuxu se Gedit instaluje jako ostatní programy:</p>
 <dl>
 <dt></dt><dt>Fedora</dt><dd><div class="highlight"><pre><span></span><span class="gp">$ </span>sudo dnf install gedit
 </pre></div></dd><dt></dt><dt>Ubuntu</dt><dd><div class="highlight"><pre><span></span><span class="gp">$ </span>sudo apt-get install gedit
 </pre></div></dd></dl><p>Používáš-li jiný Linux, předpokládám že programy instalovat umíš. :)</p>
 <p>Pro Windows a macOS se Gedit dá stáhnout z <a href="https://wiki.gnome.org/Apps/Gedit">domovské stránky</a>.</p>
-<h2>Nastavení</h2>
+<h2 id="nastaveni">Nastavení
+<a href="#nastaveni" class="permanent-link">#</a>
+</h2>
 <p>...</p>
 <dl>
 <dt></dt><dt>Číslování řádků</dt><dd><p>V sekci Zobrazit/<span class="en">View</span> vyber
 Zobrazovat čísla řádků/<span class="en">Display Line Numbers</span>.</p>
 <p><span class="figure"><a href="naucse:static?filename=gedit_linenums.png"><img src="naucse:static?filename=gedit_linenums.png" alt=""></a></span></p>
 </dd></dl><p>...</p>
-<h2>Nácvik odsazování</h2>
+<h2 id="nacvik_odsazovani">Nácvik odsazování
+<a href="#nacvik_odsazovani" class="permanent-link">#</a>
+</h2>
 <p>...</p>

--- a/test_naucse_render/fixtures/expected-compiled/default/install-editor/index.html
+++ b/test_naucse_render/fixtures/expected-compiled/default/install-editor/index.html
@@ -1,5 +1,7 @@
 <p>...</p>
-<h2>Co programátorský editor umí</h2>
+<h2 id="co_programatorsky_editor_umi">Co programátorský editor umí
+<a href="#co_programatorsky_editor_umi" class="permanent-link">#</a>
+</h2>
 <p>...</p>
 <dl>
 <dt></dt><dt>Podpora více souborů</dt><dd><p>Větší projekty sestávají z více souborů, které můžeš mít v editoru
@@ -11,7 +13,9 @@ To se bude velice hodit, až Python bude nadávat, že chyba je na řádku 183.<
 <div class="highlight"><pre><span></span>    <span class="mi">1</span>  <span class="nd">@app</span><span class="o">.</span><span class="n">route</span><span class="p">(</span><span class="s1">&#39;/courses/&lt;course:course&gt;/&#39;</span><span class="p">)</span>
     <span class="mi">2</span>  <span class="k">def</span> <span class="nf">course_page</span><span class="p">(</span><span class="n">course</span><span class="p">):</span>
     <span class="mi">3</span>      <span class="o">...</span>
-</pre></div></div><h2>Volba a nastavení editoru</h2>
+</pre></div></div><h2 id="volba_a_nastaveni_editoru">Volba a nastavení editoru
+<a href="#volba_a_nastaveni_editoru" class="permanent-link">#</a>
+</h2>
 <p>...</p>
 <ul>
 <li><a href="naucse:page?lesson=beginners/install-editor&amp;page=atom">Atom</a> – doporučený editor pro

--- a/test_naucse_render/fixtures/expected-compiled/default/install-editor/index.html
+++ b/test_naucse_render/fixtures/expected-compiled/default/install-editor/index.html
@@ -1,6 +1,6 @@
 <p>...</p>
 <h2 id="co_programatorsky_editor_umi">Co programátorský editor umí
-<a href="#co_programatorsky_editor_umi" class="permanent-link">#</a>
+<a href="#header-co_programatorsky_editor_umi" class="header-link">#</a>
 </h2>
 <p>...</p>
 <dl>
@@ -14,7 +14,7 @@ To se bude velice hodit, až Python bude nadávat, že chyba je na řádku 183.<
     <span class="mi">2</span>  <span class="k">def</span> <span class="nf">course_page</span><span class="p">(</span><span class="n">course</span><span class="p">):</span>
     <span class="mi">3</span>      <span class="o">...</span>
 </pre></div></div><h2 id="volba_a_nastaveni_editoru">Volba a nastavení editoru
-<a href="#volba_a_nastaveni_editoru" class="permanent-link">#</a>
+<a href="#header-volba_a_nastaveni_editoru" class="header-link">#</a>
 </h2>
 <p>...</p>
 <ul>

--- a/test_naucse_render/fixtures/expected-compiled/lessons/install-editor/atom.html
+++ b/test_naucse_render/fixtures/expected-compiled/lessons/install-editor/atom.html
@@ -1,11 +1,19 @@
-<h1>Instalace  Atomu</h1>
+<h1 id="instalace_atomu">Instalace  Atomu
+<a href="#instalace_atomu" class="permanent-link">#</a>
+</h1>
 <p>Editor Atom
 si stáhni z jeho <a href="https://atom.io">domovské stránky</a>
 a nainstaluj.</p>
-<h2>Nastavení</h2>
+<h2 id="nastaveni">Nastavení
+<a href="#nastaveni" class="permanent-link">#</a>
+</h2>
 <p>... jakmile v tomhle editoru vytvoříš nový soubor,
 měl/a bys ho co nejdřív uložit pod správným jménem.</p>
-<h2>Kontrola stylu zdrojového kódu</h2>
+<h2 id="kontrola_stylu_zdrojoveho_kodu">Kontrola stylu zdrojového kódu
+<a href="#kontrola_stylu_zdrojoveho_kodu" class="permanent-link">#</a>
+</h2>
 <p>...</p>
-<h2>Nácvik odsazování</h2>
+<h2 id="nacvik_odsazovani">Nácvik odsazování
+<a href="#nacvik_odsazovani" class="permanent-link">#</a>
+</h2>
 <p>...</p>

--- a/test_naucse_render/fixtures/expected-compiled/lessons/install-editor/atom.html
+++ b/test_naucse_render/fixtures/expected-compiled/lessons/install-editor/atom.html
@@ -1,19 +1,19 @@
 <h1 id="instalace_atomu">Instalace  Atomu
-<a href="#instalace_atomu" class="permanent-link">#</a>
+<a href="#header-instalace_atomu" class="header-link">#</a>
 </h1>
 <p>Editor Atom
 si stáhni z jeho <a href="https://atom.io">domovské stránky</a>
 a nainstaluj.</p>
 <h2 id="nastaveni">Nastavení
-<a href="#nastaveni" class="permanent-link">#</a>
+<a href="#header-nastaveni" class="header-link">#</a>
 </h2>
 <p>... jakmile v tomhle editoru vytvoříš nový soubor,
 měl/a bys ho co nejdřív uložit pod správným jménem.</p>
 <h2 id="kontrola_stylu_zdrojoveho_kodu">Kontrola stylu zdrojového kódu
-<a href="#kontrola_stylu_zdrojoveho_kodu" class="permanent-link">#</a>
+<a href="#header-kontrola_stylu_zdrojoveho_kodu" class="header-link">#</a>
 </h2>
 <p>...</p>
 <h2 id="nacvik_odsazovani">Nácvik odsazování
-<a href="#nacvik_odsazovani" class="permanent-link">#</a>
+<a href="#header-nacvik_odsazovani" class="header-link">#</a>
 </h2>
 <p>...</p>

--- a/test_naucse_render/fixtures/expected-compiled/lessons/install-editor/gedit.html
+++ b/test_naucse_render/fixtures/expected-compiled/lessons/install-editor/gedit.html
@@ -1,5 +1,5 @@
 <h1 id="instalace_geditu">Instalace  Geditu
-<a href="#instalace_geditu" class="permanent-link">#</a>
+<a href="#header-instalace_geditu" class="header-link">#</a>
 </h1>
 <p>Na Linuxu se Gedit instaluje jako ostatní programy:</p>
 <dl>
@@ -8,7 +8,7 @@
 </pre></div></dd></dl><p>Používáš-li jiný Linux, předpokládám že programy instalovat umíš. :)</p>
 <p>Pro Windows a macOS se Gedit dá stáhnout z <a href="https://wiki.gnome.org/Apps/Gedit">domovské stránky</a>.</p>
 <h2 id="nastaveni">Nastavení
-<a href="#nastaveni" class="permanent-link">#</a>
+<a href="#header-nastaveni" class="header-link">#</a>
 </h2>
 <p>...</p>
 <dl>
@@ -17,6 +17,6 @@ Zobrazovat čísla řádků/<span class="en">Display Line Numbers</span>.</p>
 <p><span class="figure"><a href="naucse:static?filename=gedit_linenums.png"><img src="naucse:static?filename=gedit_linenums.png" alt=""></a></span></p>
 </dd></dl><p>...</p>
 <h2 id="nacvik_odsazovani">Nácvik odsazování
-<a href="#nacvik_odsazovani" class="permanent-link">#</a>
+<a href="#header-nacvik_odsazovani" class="header-link">#</a>
 </h2>
 <p>...</p>

--- a/test_naucse_render/fixtures/expected-compiled/lessons/install-editor/gedit.html
+++ b/test_naucse_render/fixtures/expected-compiled/lessons/install-editor/gedit.html
@@ -1,16 +1,22 @@
-<h1>Instalace  Geditu</h1>
+<h1 id="instalace_geditu">Instalace  Geditu
+<a href="#instalace_geditu" class="permanent-link">#</a>
+</h1>
 <p>Na Linuxu se Gedit instaluje jako ostatní programy:</p>
 <dl>
 <dt></dt><dt>Fedora</dt><dd><div class="highlight"><pre><span></span><span class="gp">$ </span>sudo dnf install gedit
 </pre></div></dd><dt></dt><dt>Ubuntu</dt><dd><div class="highlight"><pre><span></span><span class="gp">$ </span>sudo apt-get install gedit
 </pre></div></dd></dl><p>Používáš-li jiný Linux, předpokládám že programy instalovat umíš. :)</p>
 <p>Pro Windows a macOS se Gedit dá stáhnout z <a href="https://wiki.gnome.org/Apps/Gedit">domovské stránky</a>.</p>
-<h2>Nastavení</h2>
+<h2 id="nastaveni">Nastavení
+<a href="#nastaveni" class="permanent-link">#</a>
+</h2>
 <p>...</p>
 <dl>
 <dt></dt><dt>Číslování řádků</dt><dd><p>V sekci Zobrazit/<span class="en">View</span> vyber
 Zobrazovat čísla řádků/<span class="en">Display Line Numbers</span>.</p>
 <p><span class="figure"><a href="naucse:static?filename=gedit_linenums.png"><img src="naucse:static?filename=gedit_linenums.png" alt=""></a></span></p>
 </dd></dl><p>...</p>
-<h2>Nácvik odsazování</h2>
+<h2 id="nacvik_odsazovani">Nácvik odsazování
+<a href="#nacvik_odsazovani" class="permanent-link">#</a>
+</h2>
 <p>...</p>

--- a/test_naucse_render/fixtures/expected-compiled/lessons/install-editor/index.html
+++ b/test_naucse_render/fixtures/expected-compiled/lessons/install-editor/index.html
@@ -1,5 +1,7 @@
 <p>...</p>
-<h2>Co programátorský editor umí</h2>
+<h2 id="co_programatorsky_editor_umi">Co programátorský editor umí
+<a href="#co_programatorsky_editor_umi" class="permanent-link">#</a>
+</h2>
 <p>...</p>
 <dl>
 <dt></dt><dt>Podpora více souborů</dt><dd><p>Větší projekty sestávají z více souborů, které můžeš mít v editoru
@@ -11,7 +13,9 @@ To se bude velice hodit, až Python bude nadávat, že chyba je na řádku 183.<
 <div class="highlight"><pre><span></span>    <span class="mi">1</span>  <span class="nd">@app</span><span class="o">.</span><span class="n">route</span><span class="p">(</span><span class="s1">&#39;/courses/&lt;course:course&gt;/&#39;</span><span class="p">)</span>
     <span class="mi">2</span>  <span class="k">def</span> <span class="nf">course_page</span><span class="p">(</span><span class="n">course</span><span class="p">):</span>
     <span class="mi">3</span>      <span class="o">...</span>
-</pre></div></div><h2>Volba a nastavení editoru</h2>
+</pre></div></div><h2 id="volba_a_nastaveni_editoru">Volba a nastavení editoru
+<a href="#volba_a_nastaveni_editoru" class="permanent-link">#</a>
+</h2>
 <p>...</p>
 <ul>
 <li><a href="naucse:page?lesson=beginners/install-editor&amp;page=atom">Atom</a> – doporučený editor pro

--- a/test_naucse_render/fixtures/expected-compiled/lessons/install-editor/index.html
+++ b/test_naucse_render/fixtures/expected-compiled/lessons/install-editor/index.html
@@ -1,6 +1,6 @@
 <p>...</p>
 <h2 id="co_programatorsky_editor_umi">Co programátorský editor umí
-<a href="#co_programatorsky_editor_umi" class="permanent-link">#</a>
+<a href="#header-co_programatorsky_editor_umi" class="header-link">#</a>
 </h2>
 <p>...</p>
 <dl>
@@ -14,7 +14,7 @@ To se bude velice hodit, až Python bude nadávat, že chyba je na řádku 183.<
     <span class="mi">2</span>  <span class="k">def</span> <span class="nf">course_page</span><span class="p">(</span><span class="n">course</span><span class="p">):</span>
     <span class="mi">3</span>      <span class="o">...</span>
 </pre></div></div><h2 id="volba_a_nastaveni_editoru">Volba a nastavení editoru
-<a href="#volba_a_nastaveni_editoru" class="permanent-link">#</a>
+<a href="#header-volba_a_nastaveni_editoru" class="header-link">#</a>
 </h2>
 <p>...</p>
 <ul>

--- a/test_naucse_render/fixtures/expected-dumps/beginners/install-editor.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/beginners/install-editor.yaml
@@ -7,13 +7,18 @@ data:
             atom:
                 attribution:
                 - Pro PyLadies Brno napsal Petr Viktorin, 2014-2017
-                content: "<h1>Instalace  Atomu</h1>\n<p>Editor Atom\nsi st\xE1hni\
-                    \ z\_jeho <a href=\"https://atom.io\">domovsk\xE9 str\xE1nky</a>\n\
-                    a nainstaluj.</p>\n<h2>Nastaven\xED</h2>\n<p>... jakmile v\_tomhle\
-                    \ editoru vytvo\u0159\xED\u0161 nov\xFD soubor,\nm\u011Bl/a bys\
-                    \ ho co nejd\u0159\xEDv ulo\u017Eit pod spr\xE1vn\xFDm jm\xE9\
-                    nem.</p>\n<h2>Kontrola stylu zdrojov\xE9ho k\xF3du</h2>\n<p>...</p>\n\
-                    <h2>N\xE1cvik odsazov\xE1n\xED</h2>\n<p>...</p>"
+                content: "<h1 id=\"instalace_atomu\">Instalace  Atomu\n<a href=\"\
+                    #instalace_atomu\" class=\"permanent-link\">#</a>\n</h1>\n<p>Editor\
+                    \ Atom\nsi st\xE1hni z\_jeho <a href=\"https://atom.io\">domovsk\xE9\
+                    \ str\xE1nky</a>\na nainstaluj.</p>\n<h2 id=\"nastaveni\">Nastaven\xED\
+                    \n<a href=\"#nastaveni\" class=\"permanent-link\">#</a>\n</h2>\n\
+                    <p>... jakmile v\_tomhle editoru vytvo\u0159\xED\u0161 nov\xFD\
+                    \ soubor,\nm\u011Bl/a bys ho co nejd\u0159\xEDv ulo\u017Eit pod\
+                    \ spr\xE1vn\xFDm jm\xE9nem.</p>\n<h2 id=\"kontrola_stylu_zdrojoveho_kodu\"\
+                    >Kontrola stylu zdrojov\xE9ho k\xF3du\n<a href=\"#kontrola_stylu_zdrojoveho_kodu\"\
+                    \ class=\"permanent-link\">#</a>\n</h2>\n<p>...</p>\n<h2 id=\"\
+                    nacvik_odsazovani\">N\xE1cvik odsazov\xE1n\xED\n<a href=\"#nacvik_odsazovani\"\
+                    \ class=\"permanent-link\">#</a>\n</h2>\n<p>...</p>"
                 license: cc-by-sa-40
                 slug: atom
                 solutions: []
@@ -23,23 +28,27 @@ data:
             gedit:
                 attribution:
                 - Pro PyLadies Brno napsal Petr Viktorin, 2014-2017
-                content: "<h1>Instalace  Geditu</h1>\n<p>Na Linuxu se Gedit instaluje\
-                    \ jako ostatn\xED programy:</p>\n<dl>\n<dt></dt><dt>Fedora</dt><dd><div\
-                    \ class=\"highlight\"><pre><span></span><span class=\"gp\">$ </span>sudo\
-                    \ dnf install gedit\n</pre></div></dd><dt></dt><dt>Ubuntu</dt><dd><div\
+                content: "<h1 id=\"instalace_geditu\">Instalace  Geditu\n<a href=\"\
+                    #instalace_geditu\" class=\"permanent-link\">#</a>\n</h1>\n<p>Na\
+                    \ Linuxu se Gedit instaluje jako ostatn\xED programy:</p>\n<dl>\n\
+                    <dt></dt><dt>Fedora</dt><dd><div class=\"highlight\"><pre><span></span><span\
+                    \ class=\"gp\">$ </span>sudo dnf install gedit\n</pre></div></dd><dt></dt><dt>Ubuntu</dt><dd><div\
                     \ class=\"highlight\"><pre><span></span><span class=\"gp\">$ </span>sudo\
                     \ apt-get install gedit\n</pre></div></dd></dl><p>Pou\u017E\xED\
                     v\xE1\u0161-li jin\xFD Linux, p\u0159edpokl\xE1d\xE1m \u017Ee\
                     \ programy instalovat um\xED\u0161. :)</p>\n<p>Pro Windows a macOS\
                     \ se Gedit d\xE1 st\xE1hnout z\_<a href=\"https://wiki.gnome.org/Apps/Gedit\"\
-                    >domovsk\xE9 str\xE1nky</a>.</p>\n<h2>Nastaven\xED</h2>\n<p>...</p>\n\
-                    <dl>\n<dt></dt><dt>\u010C\xEDslov\xE1n\xED \u0159\xE1dk\u016F\
-                    </dt><dd><p>V\_sekci Zobrazit/<span class=\"en\">View</span> vyber\n\
-                    Zobrazovat \u010D\xEDsla \u0159\xE1dk\u016F/<span class=\"en\"\
-                    >Display Line Numbers</span>.</p>\n<p><span class=\"figure\"><a\
-                    \ href=\"naucse:static?filename=gedit_linenums.png\"><img src=\"\
+                    >domovsk\xE9 str\xE1nky</a>.</p>\n<h2 id=\"nastaveni\">Nastaven\xED\
+                    \n<a href=\"#nastaveni\" class=\"permanent-link\">#</a>\n</h2>\n\
+                    <p>...</p>\n<dl>\n<dt></dt><dt>\u010C\xEDslov\xE1n\xED \u0159\xE1\
+                    dk\u016F</dt><dd><p>V\_sekci Zobrazit/<span class=\"en\">View</span>\
+                    \ vyber\nZobrazovat \u010D\xEDsla \u0159\xE1dk\u016F/<span class=\"\
+                    en\">Display Line Numbers</span>.</p>\n<p><span class=\"figure\"\
+                    ><a href=\"naucse:static?filename=gedit_linenums.png\"><img src=\"\
                     naucse:static?filename=gedit_linenums.png\" alt=\"\"></a></span></p>\n\
-                    </dd></dl><p>...</p>\n<h2>N\xE1cvik odsazov\xE1n\xED</h2>\n<p>...</p>"
+                    </dd></dl><p>...</p>\n<h2 id=\"nacvik_odsazovani\">N\xE1cvik odsazov\xE1\
+                    n\xED\n<a href=\"#nacvik_odsazovani\" class=\"permanent-link\"\
+                    >#</a>\n</h2>\n<p>...</p>"
                 license: cc-by-sa-40
                 slug: gedit
                 solutions: []
@@ -49,26 +58,29 @@ data:
             index:
                 attribution:
                 - Pro PyLadies Brno napsal Petr Viktorin, 2014-2017
-                content: "<p>...</p>\n<h2>Co program\xE1torsk\xFD editor um\xED</h2>\n\
-                    <p>...</p>\n<dl>\n<dt></dt><dt>Podpora v\xEDce soubor\u016F</dt><dd><p>V\u011B\
-                    t\u0161\xED projekty sest\xE1vaj\xED z\_v\xEDce soubor\u016F,\
-                    \ kter\xE9 m\u016F\u017Ee\u0161 m\xEDt v\_editoru\notev\u0159\
-                    en\xE9 v\u0161echny najednou.</p>\n</dd><dt></dt><dt>\u010C\xED\
-                    slov\xE1n\xED \u0159\xE1dk\u016F</dt><dd><p>P\u0159ed ka\u017E\
-                    d\xFDm \u0159\xE1dkem se ukazuje \u010D\xEDslo.\nTo se bude velice\
-                    \ hodit, a\u017E Python bude nad\xE1vat, \u017Ee chyba je na \u0159\
-                    \xE1dku 183.</p>\n</dd></dl><p>...</p>\n<div class=\"admonition\
-                    \ note\"><p>Pro ilustraci, takhle m\u016F\u017Ee v\_editoru vypadat\
-                    \ kousek k\xF3du:</p>\n<div class=\"highlight\"><pre><span></span>\
-                    \    <span class=\"mi\">1</span>  <span class=\"nd\">@app</span><span\
-                    \ class=\"o\">.</span><span class=\"n\">route</span><span class=\"\
-                    p\">(</span><span class=\"s1\">&#39;/courses/&lt;course:course&gt;/&#39;</span><span\
+                content: "<p>...</p>\n<h2 id=\"co_programatorsky_editor_umi\">Co program\xE1\
+                    torsk\xFD editor um\xED\n<a href=\"#co_programatorsky_editor_umi\"\
+                    \ class=\"permanent-link\">#</a>\n</h2>\n<p>...</p>\n<dl>\n<dt></dt><dt>Podpora\
+                    \ v\xEDce soubor\u016F</dt><dd><p>V\u011Bt\u0161\xED projekty\
+                    \ sest\xE1vaj\xED z\_v\xEDce soubor\u016F, kter\xE9 m\u016F\u017E\
+                    e\u0161 m\xEDt v\_editoru\notev\u0159en\xE9 v\u0161echny najednou.</p>\n\
+                    </dd><dt></dt><dt>\u010C\xEDslov\xE1n\xED \u0159\xE1dk\u016F</dt><dd><p>P\u0159\
+                    ed ka\u017Ed\xFDm \u0159\xE1dkem se ukazuje \u010D\xEDslo.\nTo\
+                    \ se bude velice hodit, a\u017E Python bude nad\xE1vat, \u017E\
+                    e chyba je na \u0159\xE1dku 183.</p>\n</dd></dl><p>...</p>\n<div\
+                    \ class=\"admonition note\"><p>Pro ilustraci, takhle m\u016F\u017E\
+                    e v\_editoru vypadat kousek k\xF3du:</p>\n<div class=\"highlight\"\
+                    ><pre><span></span>    <span class=\"mi\">1</span>  <span class=\"\
+                    nd\">@app</span><span class=\"o\">.</span><span class=\"n\">route</span><span\
+                    \ class=\"p\">(</span><span class=\"s1\">&#39;/courses/&lt;course:course&gt;/&#39;</span><span\
                     \ class=\"p\">)</span>\n    <span class=\"mi\">2</span>  <span\
                     \ class=\"k\">def</span> <span class=\"nf\">course_page</span><span\
                     \ class=\"p\">(</span><span class=\"n\">course</span><span class=\"\
                     p\">):</span>\n    <span class=\"mi\">3</span>      <span class=\"\
-                    o\">...</span>\n</pre></div></div><h2>Volba a nastaven\xED editoru</h2>\n\
-                    <p>...</p>\n<ul>\n<li><a href=\"naucse:page?lesson=beginners/install-editor&amp;page=atom\"\
+                    o\">...</span>\n</pre></div></div><h2 id=\"volba_a_nastaveni_editoru\"\
+                    >Volba a nastaven\xED editoru\n<a href=\"#volba_a_nastaveni_editoru\"\
+                    \ class=\"permanent-link\">#</a>\n</h2>\n<p>...</p>\n<ul>\n<li><a\
+                    \ href=\"naucse:page?lesson=beginners/install-editor&amp;page=atom\"\
                     >Atom</a> \u2013 doporu\u010Den\xFD editor pro\nWindows a macOS.</li>\n\
                     </ul>\n<p>...</p>\n<ul>\n<li><a href=\"naucse:page?lesson=beginners/install-editor&amp;page=gedit\"\
                     >Gedit</a> \u2013 b\xFDv\xE1 na syst\xE9mech s\_prost\u0159ed\xED\

--- a/test_naucse_render/fixtures/expected-dumps/beginners/install-editor.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/beginners/install-editor.yaml
@@ -8,17 +8,17 @@ data:
                 attribution:
                 - Pro PyLadies Brno napsal Petr Viktorin, 2014-2017
                 content: "<h1 id=\"instalace_atomu\">Instalace  Atomu\n<a href=\"\
-                    #instalace_atomu\" class=\"permanent-link\">#</a>\n</h1>\n<p>Editor\
-                    \ Atom\nsi st\xE1hni z\_jeho <a href=\"https://atom.io\">domovsk\xE9\
-                    \ str\xE1nky</a>\na nainstaluj.</p>\n<h2 id=\"nastaveni\">Nastaven\xED\
-                    \n<a href=\"#nastaveni\" class=\"permanent-link\">#</a>\n</h2>\n\
-                    <p>... jakmile v\_tomhle editoru vytvo\u0159\xED\u0161 nov\xFD\
-                    \ soubor,\nm\u011Bl/a bys ho co nejd\u0159\xEDv ulo\u017Eit pod\
-                    \ spr\xE1vn\xFDm jm\xE9nem.</p>\n<h2 id=\"kontrola_stylu_zdrojoveho_kodu\"\
-                    >Kontrola stylu zdrojov\xE9ho k\xF3du\n<a href=\"#kontrola_stylu_zdrojoveho_kodu\"\
-                    \ class=\"permanent-link\">#</a>\n</h2>\n<p>...</p>\n<h2 id=\"\
-                    nacvik_odsazovani\">N\xE1cvik odsazov\xE1n\xED\n<a href=\"#nacvik_odsazovani\"\
-                    \ class=\"permanent-link\">#</a>\n</h2>\n<p>...</p>"
+                    #header-instalace_atomu\" class=\"header-link\">#</a>\n</h1>\n\
+                    <p>Editor Atom\nsi st\xE1hni z\_jeho <a href=\"https://atom.io\"\
+                    >domovsk\xE9 str\xE1nky</a>\na nainstaluj.</p>\n<h2 id=\"nastaveni\"\
+                    >Nastaven\xED\n<a href=\"#header-nastaveni\" class=\"header-link\"\
+                    >#</a>\n</h2>\n<p>... jakmile v\_tomhle editoru vytvo\u0159\xED\
+                    \u0161 nov\xFD soubor,\nm\u011Bl/a bys ho co nejd\u0159\xEDv ulo\u017E\
+                    it pod spr\xE1vn\xFDm jm\xE9nem.</p>\n<h2 id=\"kontrola_stylu_zdrojoveho_kodu\"\
+                    >Kontrola stylu zdrojov\xE9ho k\xF3du\n<a href=\"#header-kontrola_stylu_zdrojoveho_kodu\"\
+                    \ class=\"header-link\">#</a>\n</h2>\n<p>...</p>\n<h2 id=\"nacvik_odsazovani\"\
+                    >N\xE1cvik odsazov\xE1n\xED\n<a href=\"#header-nacvik_odsazovani\"\
+                    \ class=\"header-link\">#</a>\n</h2>\n<p>...</p>"
                 license: cc-by-sa-40
                 slug: atom
                 solutions: []
@@ -29,9 +29,9 @@ data:
                 attribution:
                 - Pro PyLadies Brno napsal Petr Viktorin, 2014-2017
                 content: "<h1 id=\"instalace_geditu\">Instalace  Geditu\n<a href=\"\
-                    #instalace_geditu\" class=\"permanent-link\">#</a>\n</h1>\n<p>Na\
-                    \ Linuxu se Gedit instaluje jako ostatn\xED programy:</p>\n<dl>\n\
-                    <dt></dt><dt>Fedora</dt><dd><div class=\"highlight\"><pre><span></span><span\
+                    #header-instalace_geditu\" class=\"header-link\">#</a>\n</h1>\n\
+                    <p>Na Linuxu se Gedit instaluje jako ostatn\xED programy:</p>\n\
+                    <dl>\n<dt></dt><dt>Fedora</dt><dd><div class=\"highlight\"><pre><span></span><span\
                     \ class=\"gp\">$ </span>sudo dnf install gedit\n</pre></div></dd><dt></dt><dt>Ubuntu</dt><dd><div\
                     \ class=\"highlight\"><pre><span></span><span class=\"gp\">$ </span>sudo\
                     \ apt-get install gedit\n</pre></div></dd></dl><p>Pou\u017E\xED\
@@ -39,16 +39,16 @@ data:
                     \ programy instalovat um\xED\u0161. :)</p>\n<p>Pro Windows a macOS\
                     \ se Gedit d\xE1 st\xE1hnout z\_<a href=\"https://wiki.gnome.org/Apps/Gedit\"\
                     >domovsk\xE9 str\xE1nky</a>.</p>\n<h2 id=\"nastaveni\">Nastaven\xED\
-                    \n<a href=\"#nastaveni\" class=\"permanent-link\">#</a>\n</h2>\n\
-                    <p>...</p>\n<dl>\n<dt></dt><dt>\u010C\xEDslov\xE1n\xED \u0159\xE1\
-                    dk\u016F</dt><dd><p>V\_sekci Zobrazit/<span class=\"en\">View</span>\
-                    \ vyber\nZobrazovat \u010D\xEDsla \u0159\xE1dk\u016F/<span class=\"\
-                    en\">Display Line Numbers</span>.</p>\n<p><span class=\"figure\"\
-                    ><a href=\"naucse:static?filename=gedit_linenums.png\"><img src=\"\
-                    naucse:static?filename=gedit_linenums.png\" alt=\"\"></a></span></p>\n\
-                    </dd></dl><p>...</p>\n<h2 id=\"nacvik_odsazovani\">N\xE1cvik odsazov\xE1\
-                    n\xED\n<a href=\"#nacvik_odsazovani\" class=\"permanent-link\"\
-                    >#</a>\n</h2>\n<p>...</p>"
+                    \n<a href=\"#header-nastaveni\" class=\"header-link\">#</a>\n\
+                    </h2>\n<p>...</p>\n<dl>\n<dt></dt><dt>\u010C\xEDslov\xE1n\xED\
+                    \ \u0159\xE1dk\u016F</dt><dd><p>V\_sekci Zobrazit/<span class=\"\
+                    en\">View</span> vyber\nZobrazovat \u010D\xEDsla \u0159\xE1dk\u016F\
+                    /<span class=\"en\">Display Line Numbers</span>.</p>\n<p><span\
+                    \ class=\"figure\"><a href=\"naucse:static?filename=gedit_linenums.png\"\
+                    ><img src=\"naucse:static?filename=gedit_linenums.png\" alt=\"\
+                    \"></a></span></p>\n</dd></dl><p>...</p>\n<h2 id=\"nacvik_odsazovani\"\
+                    >N\xE1cvik odsazov\xE1n\xED\n<a href=\"#header-nacvik_odsazovani\"\
+                    \ class=\"header-link\">#</a>\n</h2>\n<p>...</p>"
                 license: cc-by-sa-40
                 slug: gedit
                 solutions: []
@@ -59,8 +59,8 @@ data:
                 attribution:
                 - Pro PyLadies Brno napsal Petr Viktorin, 2014-2017
                 content: "<p>...</p>\n<h2 id=\"co_programatorsky_editor_umi\">Co program\xE1\
-                    torsk\xFD editor um\xED\n<a href=\"#co_programatorsky_editor_umi\"\
-                    \ class=\"permanent-link\">#</a>\n</h2>\n<p>...</p>\n<dl>\n<dt></dt><dt>Podpora\
+                    torsk\xFD editor um\xED\n<a href=\"#header-co_programatorsky_editor_umi\"\
+                    \ class=\"header-link\">#</a>\n</h2>\n<p>...</p>\n<dl>\n<dt></dt><dt>Podpora\
                     \ v\xEDce soubor\u016F</dt><dd><p>V\u011Bt\u0161\xED projekty\
                     \ sest\xE1vaj\xED z\_v\xEDce soubor\u016F, kter\xE9 m\u016F\u017E\
                     e\u0161 m\xEDt v\_editoru\notev\u0159en\xE9 v\u0161echny najednou.</p>\n\
@@ -78,8 +78,8 @@ data:
                     \ class=\"p\">(</span><span class=\"n\">course</span><span class=\"\
                     p\">):</span>\n    <span class=\"mi\">3</span>      <span class=\"\
                     o\">...</span>\n</pre></div></div><h2 id=\"volba_a_nastaveni_editoru\"\
-                    >Volba a nastaven\xED editoru\n<a href=\"#volba_a_nastaveni_editoru\"\
-                    \ class=\"permanent-link\">#</a>\n</h2>\n<p>...</p>\n<ul>\n<li><a\
+                    >Volba a nastaven\xED editoru\n<a href=\"#header-volba_a_nastaveni_editoru\"\
+                    \ class=\"header-link\">#</a>\n</h2>\n<p>...</p>\n<ul>\n<li><a\
                     \ href=\"naucse:page?lesson=beginners/install-editor&amp;page=atom\"\
                     >Atom</a> \u2013 doporu\u010Den\xFD editor pro\nWindows a macOS.</li>\n\
                     </ul>\n<p>...</p>\n<ul>\n<li><a href=\"naucse:page?lesson=beginners/install-editor&amp;page=gedit\"\

--- a/test_naucse_render/test_markdown.py
+++ b/test_naucse_render/test_markdown.py
@@ -73,7 +73,7 @@ def test_markdown_header_anchor():
         # Čárky a háčky
     """)
     expected = """<h1 id="carky_a_hacky">Čárky a háčky
-<a href="#carky_a_hacky" class="permanent-link">#</a>
+<a href="#header-carky_a_hacky" class="header-link">#</a>
 </h1>"""
     assert convert_markdown(src) == expected
 

--- a/test_naucse_render/test_markdown.py
+++ b/test_naucse_render/test_markdown.py
@@ -68,6 +68,16 @@ def test_markdown_admonition_code():
     assert convert_markdown(src) == expected
 
 
+def test_markdown_header_anchor():
+    src = dedent("""
+        # Čárky a háčky
+    """)
+    expected = """<h1 id="carky_a_hacky">Čárky a háčky
+<a href="#carky_a_hacky" class="permanent-link">#</a>
+</h1>"""
+    assert convert_markdown(src) == expected
+
+
 def test_markdown_admonition_html():
     src = dedent("""
             > [note]

--- a/test_naucse_render/test_notebook.py
+++ b/test_naucse_render/test_notebook.py
@@ -33,7 +33,7 @@ def notebook(_notebook):
 def test_notebook_markdown_cell_conversion(notebook):
     markdown = dedent(r"""
         <h2 id="markdown">Markdown
-        <a href="#markdown" class="permanent-link">#</a>
+        <a href="#header-markdown" class="header-link">#</a>
         </h2>
         <p>This is <em>Markdown cell</em>!</p>
         <p>It even has some $\LaTeX$:</p>

--- a/test_naucse_render/test_notebook.py
+++ b/test_naucse_render/test_notebook.py
@@ -32,7 +32,9 @@ def notebook(_notebook):
 
 def test_notebook_markdown_cell_conversion(notebook):
     markdown = dedent(r"""
-        <h2>Markdown</h2>
+        <h2 id="markdown">Markdown
+        <a href="#markdown" class="permanent-link">#</a>
+        </h2>
         <p>This is <em>Markdown cell</em>!</p>
         <p>It even has some $\LaTeX$:</p>
         <p>$$ x = \sin(\pi) $$</p>


### PR DESCRIPTION
This allows linking to specific sections (headers) within a lesson page. I often want to send some specific part of the page to someone, but before I could only send a link to the whole page.
![anchor](https://user-images.githubusercontent.com/4539057/144246274-368108ea-bf07-471d-9bb2-fecda2229350.gif)