### PR TITLE
Simpler course definition & command to list courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ licensed under the same license.
 
 ## Changelog
 
+### naucse_render 1.7
+
+* Courses may now be specified with a "flat" file like
+  `courses/<course-slug>.yml`, rather than a `info.yml` file nested in a
+  directory.
+
+
 ### naucse_render 1.6
 
 * Courses can now specify `extra_lessons`, a list of lessons that

--- a/README.md
+++ b/README.md
@@ -6,21 +6,27 @@ naucse.python.cz JSON API.
 
 # Entrypoints
 
-There are two public entrypoints: one for getting general course information;
-the other for a subset of lessons.
+Get a list of available courses:
 
-(This separation means the content doesn't need to be rendered to get course
-info.)
+`naucse_render.get_course_slugs(*, path='.')`
+
+Get general course information:
 
 `naucse_render.get_course(course_slug, *, path='.', version=None)`
 
+Get information about lessons:
+
 `naucse_render.get_lessons(lesson_slugs, vars=None, path='.')`
+
+Compile a given course into a directory of JSON & HTML files:
+
+`def compile(slug=None, *, path='.', destination, edit_info=None)`
 
 The `path` specifies the local filesystem path to the root of the repository
 (i.e. parent directory of `courses`, `runs` and `lessons`).
 
 
-# Installation & Usage
+# Installation & CLI Usage
 
 Install the latest released version from PyPI.
 With an activated virtualenv, do:
@@ -54,6 +60,8 @@ To output metadata for a course or individual lesson(s):
 By default, data is retreived from the current working directory.
 Use the `--path` option to point naucse_render elsewhere.
 
+You can use `--help` for more info.
+
 
 ## Tests
 
@@ -83,6 +91,9 @@ licensed under the same license.
 
 ### naucse_render 1.7
 
+* Added the function `naucse.get_course_slugs()` and the CLI subcommand
+  `naucse_render ls`, which return a list of courses naucse_render can load
+  from the given directory.
 * Courses may now be specified with a "flat" file like
   `courses/<course-slug>.yml`, rather than a `info.yml` file nested in a
   directory.

--- a/naucse_render/__init__.py
+++ b/naucse_render/__init__.py
@@ -1,3 +1,3 @@
-from .course import get_course
+from .course import get_course, get_course_slugs
 from .lesson import get_lessons
 from .compile import compile

--- a/naucse_render/cli.py
+++ b/naucse_render/cli.py
@@ -24,6 +24,7 @@ def main():
     '--edit-repo-branch',
     help='Branch in the repository where the content can be edited')
 def compile(slug, path, destination, edit_repo_url, edit_repo_branch):
+    """Compile the given course to a directory with JSON & HTML data"""
     edit_info = {}
     if edit_repo_url:
         edit_info['url'] = edit_repo_url
@@ -47,6 +48,7 @@ def compile(slug, path, destination, edit_repo_url, edit_repo_branch):
     '--version',
     help='API version')
 def get_course(slug, path, version):
+    """Print a course in JSON format"""
     if path:
         path = Path(path)
     if slug == '':
@@ -62,9 +64,24 @@ def get_course(slug, path, version):
     '--path', default='.', type=click.Path(file_okay=False, exists=True),
     help='Root of the naucse data repository')
 def get_lessons(slugs, path):
+    """Print lessons in JSON format"""
     if path:
         path = Path(path)
 
     result = naucse_render.get_lessons(slugs, path=path)
+
+    print(json.dumps(result, indent=4, ensure_ascii=False))
+
+@main.command()
+@click.option(
+    '--path', default='.', type=click.Path(file_okay=False, exists=True),
+    help='Root of the naucse data repository')
+def ls(path):
+    """List slugs of available courses.
+    """
+    if path:
+        path = Path(path)
+
+    result = naucse_render.get_course_slugs(path=path)
 
     print(json.dumps(result, indent=4, ensure_ascii=False))

--- a/naucse_render/course.py
+++ b/naucse_render/course.py
@@ -48,10 +48,16 @@ def get_course(course_slug: str = None, *, path='.', version=None):
         else:
             raise ValueError(f'Invalid course slug')
 
-        info = read_yaml(
-            base_path, *path_parts, 'info.yml',
-            source_key='source_file',
-        )
+        try:
+            info = read_yaml(
+                base_path, *path_parts[:-1], path_parts[-1] + '.yml',
+                source_key='source_file',
+            )
+        except FileNotFoundError:
+            info = read_yaml(
+                base_path, *path_parts, 'info.yml',
+                source_key='source_file',
+            )
 
     # We are only concerned about the content; naucse itself will determine
     # what courses it deems canonical/meta.

--- a/naucse_render/course.py
+++ b/naucse_render/course.py
@@ -12,6 +12,25 @@ from .load import read_yaml
 from .markdown import convert_markdown
 from .encode import encode_for_json, API_VERSION
 
+def get_course_slugs(*, path='.'):
+    """Return a list of slugs of available courses.
+    The specisl "lessons" course is not returned.
+    """
+
+    base_path = Path(path).resolve()
+    def _get_slugs():
+        if (base_path / 'course.yml').exists():
+            yield None
+        for path in base_path.glob('courses/*/info.yml'):
+            yield 'courses/' + path.parent.name
+        for path in base_path.glob('courses/*.yml'):
+            yield 'courses/' + path.stem
+        for path in base_path.glob('runs/*/*/info.yml'):
+            yield path.parent.parent.name + '/' + path.parent.name
+        for path in base_path.glob('runs/*/*.yml'):
+            yield path.parent.name + '/' +  path.stem
+    return list(_get_slugs())
+
 
 def get_course(course_slug: str = None, *, path='.', version=None):
     """Get information about the course as a JSON-compatible dict

--- a/test_naucse_render/conftest.py
+++ b/test_naucse_render/conftest.py
@@ -6,6 +6,21 @@ import yaml
 
 fixture_path = Path(__file__).parent / 'fixtures'
 
+COURSE_SLUGS_GOOD = (
+    'courses/normal-course',
+    'courses/serial-test',
+    'courses/extra-lessons',
+    'courses/flat',
+    '2000/run-without-times',
+    '2000/run-with-times',
+    '2000/run-with-timezone',
+    '2000/flat',
+    None,
+)
+
+COURSE_SLUGS_BAD = {
+    'courses/bad-serial': TypeError,
+}
 
 def assert_yaml_dump(data, filename):
     """Assert that JSON-compatible "data" matches a given YAML dump

--- a/test_naucse_render/fixtures/expected-compiled/2000/flat/course.json
+++ b/test_naucse_render/fixtures/expected-compiled/2000/flat/course.json
@@ -1,0 +1,19 @@
+{
+    "api_version": [
+        0,
+        3
+    ],
+    "course": {
+        "lessons": {},
+        "sessions": [
+            {
+                "date": "2000-01-01",
+                "slug": "normal-lesson",
+                "source_file": "runs/2000/flat.yml",
+                "title": "A normal lesson"
+            }
+        ],
+        "source_file": "runs/2000/flat.yml",
+        "title": "Test run without scheduled times"
+    }
+}

--- a/test_naucse_render/fixtures/expected-compiled/courses/flat/course.json
+++ b/test_naucse_render/fixtures/expected-compiled/courses/flat/course.json
@@ -1,0 +1,18 @@
+{
+    "api_version": [
+        0,
+        3
+    ],
+    "course": {
+        "lessons": {},
+        "sessions": [
+            {
+                "slug": "normal-lesson",
+                "source_file": "courses/flat.yml",
+                "title": "A normal lesson"
+            }
+        ],
+        "source_file": "courses/flat.yml",
+        "title": "A plain vanilla course"
+    }
+}

--- a/test_naucse_render/fixtures/expected-dumps/2000/flat.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/2000/flat.yaml
@@ -1,0 +1,11 @@
+api_version:
+- 0
+- 3
+course:
+    sessions:
+    -   date: '2000-01-01'
+        slug: normal-lesson
+        source_file: runs/2000/flat.yml
+        title: A normal lesson
+    source_file: runs/2000/flat.yml
+    title: Test run without scheduled times

--- a/test_naucse_render/fixtures/expected-dumps/courses/flat.yaml
+++ b/test_naucse_render/fixtures/expected-dumps/courses/flat.yaml
@@ -1,0 +1,10 @@
+api_version:
+- 0
+- 3
+course:
+    sessions:
+    -   slug: normal-lesson
+        source_file: courses/flat.yml
+        title: A normal lesson
+    source_file: courses/flat.yml
+    title: A plain vanilla course

--- a/test_naucse_render/fixtures/test_content/courses/flat.yml
+++ b/test_naucse_render/fixtures/test_content/courses/flat.yml
@@ -1,0 +1,5 @@
+title: A plain vanilla course
+
+plan:
+- title: A normal lesson
+  slug: normal-lesson

--- a/test_naucse_render/fixtures/test_content/runs/2000/flat.yml
+++ b/test_naucse_render/fixtures/test_content/runs/2000/flat.yml
@@ -1,0 +1,6 @@
+title: Test run without scheduled times
+
+plan:
+- title: A normal lesson
+  slug: normal-lesson
+  date: 2000-01-01

--- a/test_naucse_render/test_integration.py
+++ b/test_naucse_render/test_integration.py
@@ -14,9 +14,11 @@ COURSE_SLUGS = (
     'courses/normal-course',
     'courses/serial-test',
     'courses/extra-lessons',
+    'courses/flat',
     '2000/run-without-times',
     '2000/run-with-times',
     '2000/run-with-timezone',
+    '2000/flat',
     'lessons',
     None,
 )

--- a/test_naucse_render/test_integration.py
+++ b/test_naucse_render/test_integration.py
@@ -8,20 +8,7 @@ import filecmp
 import naucse_render
 
 from test_naucse_render.conftest import assert_yaml_dump, fixture_path
-
-
-COURSE_SLUGS = (
-    'courses/normal-course',
-    'courses/serial-test',
-    'courses/extra-lessons',
-    'courses/flat',
-    '2000/run-without-times',
-    '2000/run-with-times',
-    '2000/run-with-timezone',
-    '2000/flat',
-    'lessons',
-    None,
-)
+from test_naucse_render.conftest import COURSE_SLUGS_GOOD, COURSE_SLUGS_BAD
 
 def assert_dirs_same(got: Path, expected: Path):
     cmp = filecmp.dircmp(got, expected, ignore=[])
@@ -59,7 +46,7 @@ def assert_cmp_same(cmp):
     for subcmp in cmp.subdirs.values():
         assert_cmp_same(subcmp)
 
-@pytest.mark.parametrize('slug', COURSE_SLUGS)
+@pytest.mark.parametrize('slug', (*COURSE_SLUGS_GOOD, 'lessons'))
 def test_render_course(slug):
     path = fixture_path / 'test_content'
     if slug is None:
@@ -70,7 +57,7 @@ def test_render_course(slug):
     assert_yaml_dump(course_info, slug + '.yaml')
 
 
-@pytest.mark.parametrize('slug', COURSE_SLUGS)
+@pytest.mark.parametrize('slug', (*COURSE_SLUGS_GOOD, 'lessons'))
 def test_compile_course(slug, tmp_path):
     path = fixture_path / 'test_content'
     if slug is None:
@@ -111,13 +98,9 @@ def test_render_lesson(slug):
     assert_yaml_dump(lesson_info, slug + '.yaml')
 
 
-@pytest.mark.parametrize(
-    ['slug', 'exception_type'],
-    [
-        ('courses/bad-serial', TypeError),
-    ],
-)
-def test_negative_course(slug, exception_type):
+@pytest.mark.parametrize('slug', COURSE_SLUGS_BAD)
+def test_negative_course(slug):
+    exception_type = COURSE_SLUGS_BAD[slug]
     path = fixture_path / 'test_content'
     with pytest.raises(exception_type):
         lesson_info = naucse_render.get_course(slug, path=str(path))

--- a/test_naucse_render/test_ls.py
+++ b/test_naucse_render/test_ls.py
@@ -1,0 +1,24 @@
+import json
+
+from click.testing import CliRunner
+
+import naucse_render
+from naucse_render.cli import ls
+
+from test_naucse_render.conftest import fixture_path
+from test_naucse_render.conftest import COURSE_SLUGS_GOOD, COURSE_SLUGS_BAD
+
+
+COURSE_SLUGS_ALL = set(COURSE_SLUGS_GOOD) | set(COURSE_SLUGS_BAD)
+
+def test_get_courses():
+    result = naucse_render.get_course_slugs(path=fixture_path / 'test_content')
+    assert set(result) == COURSE_SLUGS_ALL
+
+
+def test_ls_cli(monkeypatch):
+    monkeypatch.chdir(fixture_path / 'test_content')
+    runner = CliRunner()
+    result = runner.invoke(ls)
+    assert result.exit_code == 0
+    assert set(json.loads(result.output)) == COURSE_SLUGS_ALL


### PR DESCRIPTION
* Courses may now be specified with a "flat" file like
  `courses/<course-slug>.yml`, rather than a `info.yml` file nested in a
  directory.
* Added the function `naucse.get_course_slugs()` and the CLI subcommand
  `naucse_render ls`, which return a list of courses naucse_render can load
  from the given directory.
  (With this, naucse doesn't need its own logic to detect local courses.)
